### PR TITLE
Delete only the button on user action on channel

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -31,15 +31,20 @@ const takebuy = async (ctx, bot) => {
     if (!(await validateObjectId(bot, user, orderId))) return;
     const order = await Order.findOne({ _id: orderId });
     if (!(await validateTakeBuyOrder(bot, user, order))) return;
+    // We delete only the button
+    ctx.deleteMessage();
     // We change the status to trigger the expiration of this order
     // if the user don't do anything
     order.status = 'WAITING_PAYMENT';
     order.seller_id = user._id;
     order.taken_at = Date.now();
     await order.save();
+    // Now we are commenting this cause in the future we will stop showing orders
+    // on channels and we are having a bug deleting old messages
+    // ------------------------------
     // We delete the messages related to that order from the channel
-    await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message1);
-    await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message2);
+    // await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message1);
+    // await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message2);
     await messages.beginTakeBuyMessage(bot, user, order);
   } catch (error) {
     console.log(error);
@@ -66,15 +71,19 @@ const takesell = async (ctx, bot) => {
 
     const order = await Order.findOne({ _id: orderId });
     if (!(await validateTakeSellOrder(bot, user, order))) return;
-
+    // We delete only the button
+    ctx.deleteMessage();
     order.status = 'WAITING_BUYER_INVOICE';
     order.buyer_id = user._id;
     order.taken_at = Date.now();
 
     await order.save();
+    // Now we are commenting this cause in the future we will stop showing orders
+    // on channels and we are having a bug deleting old messages
+    // ------------------------------
     // We delete the messages related to that order from the channel
-    await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message1);
-    await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message2);
+    // await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message1);
+    // await bot.telegram.deleteMessage(process.env.CHANNEL, order.tg_channel_message2);
     await messages.beginTakeSellMessage(bot, user, order);
   } catch (error) {
     console.log(error);

--- a/jobs/cancel_orders.js
+++ b/jobs/cancel_orders.js
@@ -53,7 +53,7 @@ const cancelOrders = async (bot) => {
         // Instead of cancel this order we should send this to the admins 
         // and they decide what to do
         await bot.telegram.sendMessage(process.env.ADMIN_CHANNEL, `Esta orden ha expirado sin haberse completado
-Id: ${order._id}
+Id: #${order._id}
 Tipo de orden: ${order.type}
 Status: ${order.status}
 Vendedor: @${sellerUser.username}


### PR DESCRIPTION
We are having a bug deleting old messages, now we are going to delete
only the button and delete the message manually.

This will be fixed when we migrate to a new way of show orders without channels