### PR TITLE
This PR addresses two issues

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -108,6 +108,9 @@ const addInvoice = async (ctx, bot, order) => {
     let amount = order.amount;
     if (amount == 0) {
         amount = await getBtcFiatPrice(order.fiat_code, order.fiat_amount);
+        const marginPercent = order.price_margin / 100;
+        amount = amount - (amount * marginPercent);
+        amount = Math.floor(amount);
         order.fee = amount * parseFloat(process.env.FEE);
         order.amount = amount;
     }
@@ -144,8 +147,13 @@ const cancelAddInvoice = async (ctx, bot, order) => {
     }
     order.taken_at = null;
     order.status = 'PENDING';
-    if (order.price_from_api)
+    if (order.price_from_api) {
       order.amount = 0;
+      order.fee = 0;
+      order.hash = null;
+      order.secret = null;
+    }
+
     if (order.type == 'buy') {
       order.seller_id = null;
       await messages.publishBuyOrderMessage(bot, order);
@@ -179,6 +187,9 @@ const showHoldInvoice = async (ctx, bot, order) => {
     let amount;
     if (order.amount == 0) {
       amount = await getBtcFiatPrice(order.fiat_code, order.fiat_amount);
+      const marginPercent = order.price_margin / 100;
+      amount = amount - (amount * marginPercent);
+      amount = Math.floor(amount);
       order.fee = amount * parseFloat(process.env.FEE);
       order.amount = amount;
     }
@@ -216,8 +227,14 @@ const cancelShowHoldInvoice = async (ctx, bot, order) => {
     }
     order.taken_at = null;
     order.status = 'PENDING';
-    if (order.price_from_api)
+
+    if (order.price_from_api) {
       order.amount = 0;
+      order.fee = 0;
+      order.hash = null;
+      order.secret = null;
+    }
+
     if (order.type == 'buy') {
       order.seller_id = null;
       await messages.publishBuyOrderMessage(bot, order);

--- a/bot/messages.js
+++ b/bot/messages.js
@@ -34,7 +34,7 @@ Botón Vender:
 12. Antes de que cualquier otro usuario tome tu oferta de compra o venta, puedes cancelarla con el este comando
 13. Si la operación ya ha sido tomada y deseas cancelar, lo puedes realizar mediante una cancelación cooperativa, por seguridad esto solo se puede realizar si las dos partes están de acuerdo, las dos partes deben ejecutar el comando /cooperativecancel
 
-¡Intercambia seguro y rápido! #P2PLN`);
+¡Intercambia seguro y rápido!`);
   } catch (error) {
     console.log(error);
   }
@@ -112,8 +112,8 @@ const buyOrderCorrectFormatMessage = async (bot, user) => {
     await bot.telegram.sendMessage(user.tg_id, `/buy <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [margen_de_precio]`);
     await bot.telegram.sendMessage(user.tg_id, `Para crear una compra de 100 satoshis por 212121 bolívares (VES) e indicamos que el método de pago fiat es pagomovil o transferencia del banco mercantil.`);
     await bot.telegram.sendMessage(user.tg_id, `/buy 100 212121 ves "pagomovil o mercantil"`);
-    await bot.telegram.sendMessage(user.tg_id, `Para crear una orden que muestre tu username al ser publicada pero no deseas indicar el monto en satoshis, solo debes poner 0 (cero) en el campo "monto en sats" y el bot hará el cálculo con el precio del libre mercado y 'y' como último parámetro`);
-    await bot.telegram.sendMessage(user.tg_id, `/buy 0 212121 ves "pagomovil o transferencia" y`);
+    await bot.telegram.sendMessage(user.tg_id, `Para crear una orden de compra con un margen de ganancia del 3% sin indicar el monto en satoshis, solo debes poner 0 (cero) en el campo "monto en sats", el bot hará el cálculo con el precio del libre mercado y '-3' como último parámetro`);
+    await bot.telegram.sendMessage(user.tg_id, `/buy 0 212121 ves "pagomovil o transferencia" -3`);
   } catch (error) {
     console.log(error);
   }

--- a/bot/messages.js
+++ b/bot/messages.js
@@ -89,7 +89,7 @@ const pendingBuyMessage = async (bot, user, order) => {
 
 const mustBeIntMessage = async (bot, user, fieldName) => {
   try {
-    await bot.telegram.sendMessage(user.tg_id, `${fieldName} debe ser entero positivo`);
+    await bot.telegram.sendMessage(user.tg_id, `${fieldName} debe ser un número entero`);
   } catch (error) {
     console.log(error);
   }
@@ -97,11 +97,11 @@ const mustBeIntMessage = async (bot, user, fieldName) => {
 
 const sellOrderCorrectFormatMessage = async (bot, user) => {
   try {
-    await bot.telegram.sendMessage(user.tg_id, `/sell <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [mostrar_username]`);
+    await bot.telegram.sendMessage(user.tg_id, `/sell <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [margen_de_precio]`);
     await bot.telegram.sendMessage(user.tg_id, `Para crear una venta de 100 satoshis por 212121 bolívares (VES) e indicamos que el método de pago fiat es pagomovil o transferencia del banco mercantil.`);
     await bot.telegram.sendMessage(user.tg_id, `/sell 100 212121 ves "pagomovil o mercantil"`);
-    await bot.telegram.sendMessage(user.tg_id, `Para crear una orden que muestre tu username al ser publicada pero no deseas indicar el monto en satoshis, solo debes poner 0 (cero) en el campo "monto en sats" y el bot hará el cálculo con el precio del libre mercado y 'y' como último parámetro`);
-    await bot.telegram.sendMessage(user.tg_id, `/sell 0 212121 ves "pagomovil o mercantil" y`);
+    await bot.telegram.sendMessage(user.tg_id, `Para crear una venta con un margen de ganancia del 3% sin indicar el monto en satoshis, solo debes poner 0 (cero) en el campo "monto en sats", el bot hará el cálculo con el precio del libre mercado y '3' como último parámetro`);
+    await bot.telegram.sendMessage(user.tg_id, `/sell 0 212121 ves "pagomovil o transferencia" 3`);
   } catch (error) {
     console.log(error);
   }
@@ -109,11 +109,11 @@ const sellOrderCorrectFormatMessage = async (bot, user) => {
 
 const buyOrderCorrectFormatMessage = async (bot, user) => {
   try {
-    await bot.telegram.sendMessage(user.tg_id, `/buy <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [mostrar_username]`);
+    await bot.telegram.sendMessage(user.tg_id, `/buy <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [margen_de_precio]`);
     await bot.telegram.sendMessage(user.tg_id, `Para crear una compra de 100 satoshis por 212121 bolívares (VES) e indicamos que el método de pago fiat es pagomovil o transferencia del banco mercantil.`);
     await bot.telegram.sendMessage(user.tg_id, `/buy 100 212121 ves "pagomovil o mercantil"`);
     await bot.telegram.sendMessage(user.tg_id, `Para crear una orden que muestre tu username al ser publicada pero no deseas indicar el monto en satoshis, solo debes poner 0 (cero) en el campo "monto en sats" y el bot hará el cálculo con el precio del libre mercado y 'y' como último parámetro`);
-    await bot.telegram.sendMessage(user.tg_id, `/buy 0 212121 ves "pagomovil o mercantil" y`);
+    await bot.telegram.sendMessage(user.tg_id, `/buy 0 212121 ves "pagomovil o transferencia" y`);
   } catch (error) {
     console.log(error);
   }
@@ -327,7 +327,7 @@ const repeatedInvoiceMessage = async (bot, user) => {
 
 const publishBuyOrderMessage = async (bot, order) => {
   try {
-    let publishMessage = `⚡️🍊⚡️\n${order.description}\n\n`;
+    let publishMessage = `⚡️🍊⚡️\n${order.description}\n`;
     publishMessage += `Para tomar esta orden 👇`;
 
     // Mensaje al canal
@@ -351,7 +351,7 @@ const publishBuyOrderMessage = async (bot, order) => {
 
 const publishSellOrderMessage = async (bot, order) => {
   try {
-    let publishMessage = `⚡️🍊⚡️\n${order.description}\n\n`;
+    let publishMessage = `⚡️🍊⚡️\n${order.description}\n`;
     publishMessage += `Para tomar esta orden 👇`;
     const message1 = await bot.telegram.sendMessage(process.env.CHANNEL, publishMessage);
     const message2 = await bot.telegram.sendMessage(process.env.CHANNEL, order._id, {
@@ -814,6 +814,14 @@ const priceApiFailedMessage = async (bot, user) => {
   }
 };
 
+const updateUserSettingsMessage = async (bot, user, field, newState) => {
+  try {
+    await bot.telegram.sendMessage(user.tg_id, `Ha modificado el campo ${field} a ${newState}`);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 module.exports = {
   startMessage,
   initBotErrorMessage,
@@ -893,4 +901,5 @@ module.exports = {
   sellerPaidHoldMessage,
   showInfoMessage,
   sendBuyerInfo2SellerMessage,
+  updateUserSettingsMessage,
 };

--- a/bot/ordersActions.js
+++ b/bot/ordersActions.js
@@ -12,14 +12,16 @@ const createOrder = async (ctx, bot, user, {
   fiatCode,
   paymentMethod,
   status,
-  showUsername,
+  priceMargin,
 }) => {
   amount = parseInt(amount);
   const action = type == 'sell' ? 'Vendiendo' : 'Comprando';
   const trades = type == 'sell' ? seller.trades_completed : buyer.trades_completed;
   const volume = type == 'sell' ? seller.volume_traded : buyer.volume_traded;
   try {
-    const username = showUsername == 'y' ? `@${user.username} está ` : ``;
+    const username = user.show_username ? `@${user.username} está ` : ``;
+    const volumeTraded = user.show_volume_traded ? `Volumen de comercio: ${volume} sats\n` : ``;
+    const priceMarginText = !!priceMargin ? `Margen de precio: ${priceMargin}%\n` : ``;
     const currency = getCurrency(fiatCode);
     let currencyString = `${fiatCode} ${fiatAmount}`;
     if (!!currency) {
@@ -35,15 +37,16 @@ const createOrder = async (ctx, bot, user, {
         return;
       }
       amountText = '';
-      tasaText = '\nTasa: yadio.io';
+      tasaText = 'Tasa: yadio.io\n';
     }
     if (type === 'sell') {
       const fee = amount * parseFloat(process.env.FEE);
       let description = `${username}${action} ${amountText}sats\nPor ${currencyString}\n`;
       description += `Recibo pago por ${paymentMethod}\n`;
       description += `Tiene ${trades} operaciones exitosas\n`;
-      description += `Volumen de comercio: ${volume} sats`;
-      description += `${tasaText}`;
+      description += volumeTraded;
+      description += priceMarginText;
+      description += tasaText;
       const order = new Order({
         description,
         amount,
@@ -58,6 +61,7 @@ const createOrder = async (ctx, bot, user, {
         tg_chat_id: ctx.message.chat.id,
         tg_order_message: ctx.message.message_id,
         price_from_api: priceFromAPI,
+        price_margin: priceMargin || 0,
       });
       await order.save();
 
@@ -67,8 +71,9 @@ const createOrder = async (ctx, bot, user, {
       let description = `${username}${action} ${amountText}sats\nPor ${currencyString}\n`;
       description += `Pago por ${paymentMethod}\n`;
       description += `Tiene ${trades} operaciones exitosas\n`;
-      description += `Volumen de comercio: ${volume} sats`;
-      description += `${tasaText}`;
+      description += volumeTraded;
+      description += priceMarginText;
+      description += tasaText;
       const order = new Order({
         description,
         amount,
@@ -83,6 +88,7 @@ const createOrder = async (ctx, bot, user, {
         tg_chat_id: ctx.message.chat.id,
         tg_order_message: ctx.message.message_id,
         price_from_api: priceFromAPI,
+        price_margin: priceMargin || 0,
       });
       await order.save();
 

--- a/bot/start.js
+++ b/bot/start.js
@@ -78,7 +78,7 @@ const initialize = (botToken, options) => {
       const sellOrderParams = await validateSellOrder(ctx, bot, user);
 
       if (!sellOrderParams) return;
-      const { amount, fiatAmount, fiatCode, paymentMethod, showUsername } = sellOrderParams;
+      const { amount, fiatAmount, fiatCode, paymentMethod, priceMargin } = sellOrderParams;
       const order = await ordersActions.createOrder(ctx, bot, user, {
         type: 'sell',
         amount,
@@ -87,7 +87,7 @@ const initialize = (botToken, options) => {
         fiatCode,
         paymentMethod,
         status: 'PENDING',
-        showUsername,
+        priceMargin,
       });
 
       if (!!order) {
@@ -108,7 +108,7 @@ const initialize = (botToken, options) => {
       const buyOrderParams = await validateBuyOrder(ctx, bot, user);
       if (!buyOrderParams) return;
 
-      const { amount, fiatAmount, fiatCode, paymentMethod, showUsername } = buyOrderParams;
+      const { amount, fiatAmount, fiatCode, paymentMethod, priceMargin } = buyOrderParams;
       //revisar por que esta creando invoice sin monto
       const order = await ordersActions.createOrder(ctx, bot, user, {
         type: 'buy',
@@ -118,7 +118,7 @@ const initialize = (botToken, options) => {
         fiatCode,
         paymentMethod,
         status: 'PENDING',
-        showUsername,
+        priceMargin,
       });
 
       if (!!order) {
@@ -607,6 +607,40 @@ const initialize = (botToken, options) => {
       const info = await getInfo();
 
       await messages.showInfoMessage(bot, user, info);
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  bot.command('showusername', async (ctx) => {
+    try {
+      const user = await validateUser(ctx, bot, false);
+
+      if (!user) return;
+
+      let [ show ] = await validateParams(ctx, bot, user, 2, 'yes/no');
+      if (!show) return;
+      show = show == 'yes' ? true : false;
+      user.show_username = show;
+      await user.save();
+      messages.updateUserSettingsMessage(bot, user, 'showusername', show);
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
+  bot.command('showvolume', async (ctx) => {
+    try {
+      const user = await validateUser(ctx, bot, false);
+
+      if (!user) return;
+
+      let [ show ] = await validateParams(ctx, bot, user, 2, 'yes/no');
+      if (!show) return;
+      show = show == 'yes' ? true : false;
+      user.show_volume_traded = show;
+      await user.save();
+      messages.updateUserSettingsMessage(bot, user, 'showvolume', show);
     } catch (error) {
       console.log(error);
     }

--- a/bot/validations.js
+++ b/bot/validations.js
@@ -64,12 +64,13 @@ const validateSellOrder = async (ctx, bot, user) => {
       return false;
     }
 
-    let [ _, amount, fiatAmount, fiatCode, paymentMethod, showUsername ] = args;
+    let [ _, amount, fiatAmount, fiatCode, paymentMethod, priceMargin ] = args;
 
-    if (!!showUsername && showUsername != 'y') {
-      await messages.showUsernameErrorMessage(bot, user);
+    priceMargin = parseInt(priceMargin);
+    if (!!priceMargin && !Number.isInteger(priceMargin)) {
+      await messages.mustBeIntMessage(bot, user, 'margen_de_precio');
       return false;
-    }
+    };
 
     amount = parseInt(amount);
     if (!Number.isInteger(amount)) {
@@ -102,7 +103,7 @@ const validateSellOrder = async (ctx, bot, user) => {
       fiatAmount,
       fiatCode: fiatCode.toUpperCase(),
       paymentMethod,
-      showUsername,
+      priceMargin,
     };
   } catch (error) {
     console.log(error);
@@ -117,12 +118,13 @@ const validateBuyOrder = async (ctx, bot, user) => {
       await messages.buyOrderCorrectFormatMessage(bot, user);
       return false;
     }
-    let [ _, amount, fiatAmount, fiatCode, paymentMethod, showUsername ] = args;
+    let [ _, amount, fiatAmount, fiatCode, paymentMethod, priceMargin ] = args;
 
-    if (!!showUsername && showUsername != 'y') {
-      await messages.showUsernameErrorMessage(bot, user);
+    priceMargin = parseInt(priceMargin);
+    if (!!priceMargin && !Number.isInteger(priceMargin)) {
+      await messages.mustBeIntMessage(bot, user, 'margen_de_precio');
       return false;
-    }
+    };
 
     amount = parseInt(amount);
     if (!Number.isInteger(amount)) {
@@ -155,7 +157,7 @@ const validateBuyOrder = async (ctx, bot, user) => {
       fiatAmount,
       fiatCode: fiatCode.toUpperCase(),
       paymentMethod,
-      showUsername,
+      priceMargin,
     };
   } catch (error) {
     console.log(error);

--- a/models/order.js
+++ b/models/order.js
@@ -62,6 +62,7 @@ const OrderSchema = new mongoose.Schema({
   tg_group_message1: { type: String },
   tg_group_message2: { type: String },
   price_from_api: { type: Boolean },
+  price_margin: { type: Number },
   admin_warned: { type: Boolean, default: false }, // We set this to true when the bot warns admins the order is about to expire
   paid_hold_buyer_invoice_updated: { type: Boolean, default: false }, // We set this to true when buyer executes /setinvoice on a order PAID_HOLD_INVOICE
 });

--- a/models/user.js
+++ b/models/user.js
@@ -10,6 +10,8 @@ const UserSchema = new mongoose.Schema({
   volume_traded: { type: Number, min: 0, default: 0 },
   admin: { type: Boolean, default: false },
   banned: { type: Boolean, default: false },
+  show_username: { type: Boolean, default: false },
+  show_volume_traded: { type: Boolean, default: false },
   disputes: { type: Number, min: 0, default: 0 },
   created_at: { type: Date, default: Date.now },
 });

--- a/tests/bot_test.js
+++ b/tests/bot_test.js
@@ -51,7 +51,7 @@ describe('Telegram bot test', () => {
     userStub.restore();
     orderStub.restore();
     expect(updates.ok).to.be.equal(true);
-    expect(updates.result[0].message.text).to.be.equal('/sell <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [mostrar_username]');
+    expect(updates.result[0].message.text).to.be.equal('/sell <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [margen_de_precio]');
   });
 
   it('should create a /sell', async () => {
@@ -97,6 +97,6 @@ describe('Telegram bot test', () => {
     userStub.restore();
     orderStub.restore();
     expect(updates.ok).to.be.equal(true);
-    expect(updates.result[0].message.text).to.be.equal('/buy <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [mostrar_username]');
+    expect(updates.result[0].message.text).to.be.equal('/buy <monto_en_sats> <monto_en_fiat> <codigo_fiat> <método_de_pago> [margen_de_precio]');
   });
 });


### PR DESCRIPTION
The first one is #124
Allow users to add price margin when creating an invoice
We replace the last param that we were using to show username on order publish
Now the last param will be used to tell to the bot the margin as an integer

```
/sell 0 1000 ves transferencia 3

or

/buy 0 1000 ves transferencia -3
```

Positive numbers benefits sellers, negative numbers benefits buyers

The second one is #136

Add two new commands to allow users to show or not private data.

```
/showusername yes
```
Will show the user handle on every new order created, default value is no (false)

```
/showvolume yes
```
Will show the user volume traded on every new order created, default value is no (false)