### PR TITLE
Add exchange price on orders with amount of sats and fiat specified

### DIFF
--- a/bot/ordersActions.js
+++ b/bot/ordersActions.js
@@ -1,7 +1,7 @@
 const { ObjectId } = require('mongoose').Types;
 const { Order } = require('../models');
 const messages = require('./messages');
-const { getCurrency } = require('../util');
+const { getCurrency, getBtcExchangePrice } = require('../util');
 
 const createOrder = async (ctx, bot, user, {
   type,
@@ -39,6 +39,9 @@ const createOrder = async (ctx, bot, user, {
       }
       amountText = '';
       tasaText = `Tasa: ${process.env.FIAT_RATE_NAME} ${priceMarginText}\n`;
+    } else {
+      const exchangePrice = getBtcExchangePrice(fiatAmount, amount);
+      tasaText = `Precio: ${exchangePrice.toFixed(2)}\n`
     }
     if (type === 'sell') {
       const fee = amount * parseFloat(process.env.FEE);

--- a/util/index.js
+++ b/util/index.js
@@ -101,6 +101,18 @@ const getBtcFiatPrice = async (fiatCode, fiatAmount) => {
   }
 };
 
+const getBtcExchangePrice = (fiatAmount, satsAmount) => {
+  try {
+    const satsPerBtc = 1e8;
+    const feeRate = (satsPerBtc * fiatAmount) / satsAmount;
+
+    return feeRate;
+  } catch (error) {
+    console.log(error)
+  }
+};
+
+
 // Convers a string to an array of arguments
 // Source: https://stackoverflow.com/a/39304272
 const parseArgs = (cmdline) => {
@@ -154,6 +166,7 @@ module.exports = {
   getCurrency,
   handleReputationItems,
   getBtcFiatPrice,
+  getBtcExchangePrice,
   parseArgs,
   getCurrenciesWithPrice,
 };


### PR DESCRIPTION
- Create helper function to compute the price of btc in the fiat currency selected.
- Add condition and format string to display btc exchange price in case the user has specified the amount of sats and fiat.

Preview:
![image](https://user-images.githubusercontent.com/46329881/148597809-5c51e9ac-a663-4470-ae89-f27b5fa67b2a.png)
![image](https://user-images.githubusercontent.com/46329881/148597870-e71eb307-51c4-431c-a8fd-99c514b366ff.png)


Resolves #143
