### PR TITLE
Allow user to rate their counterpart after finish trade

### DIFF
--- a/bot/messages.js
+++ b/bot/messages.js
@@ -299,6 +299,22 @@ const releasedSatsMessage = async (bot, sellerUser, buyerUser) => {
   }
 };
 
+const rateUserMessage = async (bot, caller, order) => {
+  try {
+    const starButtons = []
+    for (let num = 5; num > 0; num--) {
+      starButtons.push([{text: '⭐'.repeat(num), callback_data: `showStarBtn(${num},${order._id})`}])
+    }
+    await bot.telegram.sendMessage(caller.tg_id, `Califica a tu contraparte:`, {
+      reply_markup: {
+        inline_keyboard: starButtons,
+      },
+    });
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 const notActiveOrderMessage = async (bot, user) => {
   try {
     await bot.telegram.sendMessage(user.tg_id, `Esta orden no puede ser procesada, asegúrate de que el Id es correcto`);
@@ -947,6 +963,7 @@ module.exports = {
   userCantTakeMoreThanOneWaitingOrderMessage,
   buyerReceivedSatsMessage,
   releasedSatsMessage,
+  rateUserMessage,
   listCurrenciesResponse,
   priceApiFailedMessage,
   showHoldInvoiceMessage,

--- a/bot/start.js
+++ b/bot/start.js
@@ -6,6 +6,7 @@ const ordersActions = require('./ordersActions');
 const {
   takebuy,
   takesell,
+  rateUser,
   cancelAddInvoice,
   addInvoice,
   cancelShowHoldInvoice,
@@ -607,6 +608,10 @@ const initialize = (botToken, options) => {
 
   bot.action('cancelShowHoldInvoiceBtn', async (ctx) => {
     await cancelShowHoldInvoice(ctx, bot);
+  });
+
+  bot.action(/^showStarBtn\(([1-5]),(\w{24})\)$/, async (ctx) => {
+    await rateUser(ctx, bot, ctx.match[1], ctx.match[2]);
   });
 
   bot.command('paytobuyer', async (ctx) => {

--- a/ln/pay_request.js
+++ b/ln/pay_request.js
@@ -56,6 +56,10 @@ const payToBuyer = async (bot, order) => {
       // TODO: We need to fix this, the seller should get reputation just after release
       await handleReputationItems(buyerUser, sellerUser, order.amount);
       await messages.buyerReceivedSatsMessage(bot, buyerUser, sellerUser);
+      Promise.all([
+        messages.rateUserMessage(bot, buyerUser, order),
+        messages.rateUserMessage(bot, sellerUser, order),
+      ]);
     } else {
       await messages.invoicePaymentFailedMessage(bot, buyerUser);
       const pp = new PendingPayment({

--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,11 @@
 const mongoose = require('mongoose');
 
+const UserReviewSchema = new mongoose.Schema({
+  rating: { type: Number, min: 0, max: 5, default: 0 },
+  review: { type: String, trim: true, maxlength: 140 },
+  reviewed_at: { type: Date, default: Date.now },
+})
+
 const UserSchema = new mongoose.Schema({
   tg_id: { type: String, unique: true },
   username: { type: String },
@@ -7,6 +13,8 @@ const UserSchema = new mongoose.Schema({
   last_name: { type: String },
   lang: { type: String, default: 'ESP' },
   trades_completed: { type: Number, min: 0, default: 0 },
+  total_rating: { type: Number, min: 0, max: 5, default: 0 },
+  reviews: [UserReviewSchema],
   volume_traded: { type: Number, min: 0, default: 0 },
   admin: { type: Boolean, default: false },
   banned: { type: Boolean, default: false },


### PR DESCRIPTION
This PR is divided in two milestones:
1. Logic and buttons to rate users with numbers between 1 and 5.
2. Wizard/Scene to ask for comments about users involved in trades.

The first milestones is ready to be reviewed. It includes:
- Messages to display buttons in chat.
- Bot action to trigger button logic.
- Schemas and fields to save new review data in database.
- Logic to compute data values and store them in database.
- Function calls at the end of trade workflow to ask for ratings.

Preview:
![image](https://user-images.githubusercontent.com/46329881/148855974-80b0a17f-8d47-4599-a731-bb1d61641075.png)

--- 
The second milestone is to be done, but, the database schemas are the same than
those created for the first milestone.

Resolves #118
