### PR TITLE
Allow user to comment about their counterpart after finish trade

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -179,6 +179,8 @@ const rateUser = async (ctx, bot, rating, orderId) => {
   try {
     ctx.deleteMessage();
     ctx.scene.leave();
+    const callerId = ctx.from.id;
+
     if (!orderId) return;
     const order = await Order.findOne({ _id: orderId });
 
@@ -192,7 +194,7 @@ const rateUser = async (ctx, bot, rating, orderId) => {
       return;
     }
     let targetUser = buyer;
-    if (ctx.from.id == buyer) {
+    if (callerId == buyer.tg_id) {
       targetUser = seller;
     }
 
@@ -217,7 +219,7 @@ const rateUser = async (ctx, bot, rating, orderId) => {
   } catch (error) {
     console.log(error);
   }
-}
+};
 
 const cancelAddInvoice = async (ctx, bot, order) => {
   try {

--- a/bot/commands.js
+++ b/bot/commands.js
@@ -198,8 +198,6 @@ const rateUser = async (ctx, bot, rating, orderId) => {
       targetUser = seller;
     }
 
-    // TODO: After creation of `addUserReviewWizard` the review
-    // will be added inside the wizard
     ctx.scene.enter('ADD_USER_REVIEW_WIZARD_SCENE_ID', { bot, callerId, targetUser, rating });
   } catch (error) {
     console.log(error);

--- a/bot/commands.js
+++ b/bot/commands.js
@@ -204,7 +204,14 @@ const rateUser = async (ctx, bot, rating, orderId) => {
       rating: rating,
       review: '',
     })
+  } catch (error) {
+    console.log(error);
+  }
+};
 
+const saveUserReview = async (targetUser, review) => {
+  try {
+    targetUser.reviews.push(review)
     const totalReviews = targetUser.reviews.length;
     const oldRating = targetUser.total_rating;
     const lastRating = targetUser.reviews[totalReviews - 1].rating;
@@ -346,6 +353,7 @@ module.exports = {
   takebuy,
   takesell,
   rateUser,
+  saveUserReview,
   cancelAddInvoice,
   waitPayment,
   addInvoice,

--- a/bot/commands.js
+++ b/bot/commands.js
@@ -200,10 +200,7 @@ const rateUser = async (ctx, bot, rating, orderId) => {
 
     // TODO: After creation of `addUserReviewWizard` the review
     // will be added inside the wizard
-    targetUser.reviews.push({
-      rating: rating,
-      review: '',
-    })
+    ctx.scene.enter('ADD_USER_REVIEW_WIZARD_SCENE_ID', { bot, callerId, targetUser, rating });
   } catch (error) {
     console.log(error);
   }

--- a/bot/scenes.js
+++ b/bot/scenes.js
@@ -100,19 +100,17 @@ const addUserReviewWizard = new Scenes.WizardScene(
         return;
       }
 
+      ctx.deleteMessage();
       if (comment == 'exit') {
         const exitMessage = await ctx.reply(
-          'Saliendo del modo wizard, ahora podras escribir comandos.\nSolo sera guardado el puntaje ingresado.'
+          'Saliendo del modo wizard, ahora podras escribir comandos.\nSolo fue guardado el puntaje ingresado.'
         );
-        ctx.scene.session.prev_message_id.push(exitMessage.message_id);
       } else {
         response.review = comment;
       }
 
       await saveUserReview(targetUser, response);
-  
-      ctx.deleteMessage();
-
+      
       const sceneMessages = ctx.scene.session.prev_message_id;
       if (Array.isArray(sceneMessages) && sceneMessages.length > 0) {
         sceneMessages.forEach((message) => ctx.deleteMessage(message));

--- a/bot/start.js
+++ b/bot/start.js
@@ -35,7 +35,7 @@ const {
 } = require('./validations');
 const messages = require('./messages');
 const { attemptPendingPayments, cancelOrders, deleteOrders } = require('../jobs');
-const addInvoiceWizard = require('./scenes');
+const { addInvoiceWizard,  addUserReviewWizard } = require('./scenes');
 
 const initialize = (botToken, options) => {
   const bot = new Telegraf(botToken, options);
@@ -51,7 +51,7 @@ const initialize = (botToken, options) => {
     await deleteOrders(bot);
   });
 
-  const stage = new Scenes.Stage([addInvoiceWizard]);
+  const stage = new Scenes.Stage([addInvoiceWizard, addUserReviewWizard]);
   bot.use(session());
 
   bot.use(stage.middleware());


### PR DESCRIPTION
> Second milestone of the PR #148 

This pull request includes:
- _A bug fix related to #148:_ In the function `rateUser`, there was a
  comparison between a number and an object.
- _A small refactoring:_ The `total_rating` calculus and the save of the review
  in the user's document is moved to its own function.
- _A new wizard scene:_ In this new scene the user will be able to make a
  resumed comment about the performance of their counterpart after the finish
  of their trade.

Preview:

- <ins>Successful case</ins>:
![image](https://user-images.githubusercontent.com/46329881/149218458-7e636670-5b5d-4746-a1f3-6a7db7dd6501.png)


- <ins>Too long comment case</ins>:
![image](https://user-images.githubusercontent.com/46329881/149218527-b4c5f221-ff4e-49fd-950e-8e6def92952e.png)


- <ins>Exit case</ins>:
![image](https://user-images.githubusercontent.com/46329881/149218600-ba790dbc-988e-4d56-a0b2-a618ccee2eec.png)
![image](https://user-images.githubusercontent.com/46329881/149218637-7b468a38-69c0-4d95-96c7-6b8271aca6a2.png)


---
Some very good sources of information to implement the WizardScene were:
- telegraf/telegraf#705 (IMalyugin's comment).
- [telegraf documentation](https://github.com/telegraf/telegraf/tree/v4/docs)
- [more telgraf documentation](https://telegraf.js.org/index.html)

---
Completes #148 
Resolves #118
