### PR TITLE
Fix typo in database query by user id

### DIFF
--- a/bot/commands.js
+++ b/bot/commands.js
@@ -186,7 +186,7 @@ const rateUser = async (ctx, bot, rating, orderId) => {
 
     if (!order) return;
     const buyer = await User.findOne({ _id: order.buyer_id });
-    const seller = await User.findOne({ _id: order.buyer_id });
+    const seller = await User.findOne({ _id: order.seller_id });
 
     // User can only rate other after a successful exchange
     if (order.status != 'SUCCESS') {


### PR DESCRIPTION
The `rateUser` function establishes the `targetUser` of the rating based on the user sending it.
To do that it has to get both users involved in the trade and compare them against the _id_ of the function caller.

A typo in the query to database caused that the requested users were always the buyers of the order.

Fixes #155
