### PR TITLE
Fix errors when new users take orders with not started bot

### DIFF
--- a/bot/messages.js
+++ b/bot/messages.js
@@ -1,3 +1,4 @@
+const { TelegramError } = require('telegraf');
 const { plural, getCurrency } = require('../util');
 
 const startMessage = async (ctx) => {
@@ -41,7 +42,10 @@ const initBotErrorMessage = async (bot, tgId) => {
   try {
     await bot.telegram.sendMessage(tgId, `Para usar este Bot primero debes inicializar el bot con el comando /start`);
   } catch (error) {
-    console.log(error);
+    // Ignore TelegramError - Forbidden request
+    if (!(error instanceof TelegramError && error.response.error_code == 403)) {
+      console.log(error);
+    }
   }
 };
 


### PR DESCRIPTION
Telegraf captures and wraps [Telegram API errors](https://core.telegram.org/api/errors) with their own Error types.

All telegraf errors with `error_code` equal to 403, in accordance with the
[Telegram API documentation]() are related to privacy violations.

In the case of our bot, those violations come after unsolicited "push"
actions on chats. Like the present case, when an user hasn't initiated the bot
and it takes any kind of order.

The click on any `sell` or `buy` button will trigger the bot to send a message
to the user in a private chat. That kind of action is forbidden before any explicit
allowance of the user to the bot (with `start` command).

The bot hasn't any way to warn the user about this so it is safe to just
ignore that kind of errors and wait until the user realize its mistake by its
own.

The present PR implements this last proposal.

Fixes #159 
