### PR TITLE
Refactor of createOrder function

### DIFF
--- a/bot/ordersActions.js
+++ b/bot/ordersActions.js
@@ -6,108 +6,123 @@ const { getCurrency, getBtcExchangePrice, getEmojiRate, decimalRound } = require
 const createOrder = async (ctx, bot, user, {
   type,
   amount,
-  seller,
-  buyer,
   fiatAmount,
   fiatCode,
   paymentMethod,
   status,
   priceMargin,
 }) => {
-  amount = parseInt(amount);
-  const action = type == 'sell' ? 'Vendiendo' : 'Comprando';
-  const trades = type == 'sell' ? seller.trades_completed : buyer.trades_completed;
-  const volume = type == 'sell' ? seller.volume_traded : buyer.volume_traded;
-  const totalRating = type == 'sell' ? seller.total_rating : buyer.total_rating;
-  const totalReviews = type == 'sell' ? seller.reviews.length : buyer.reviews.length;
   try {
+    amount = parseInt(amount);
+    const fee = amount * parseFloat(process.env.FEE);
+    const currency = getCurrency(fiatCode);
+    const priceFromAPI = !amount;
+
+    if (priceFromAPI && !currency.price) {
+      await messages.notRateForCurrency(bot, user);
+      return;
+    }
+
+    const baseOrderData = {
+      amount,
+      fee,
+      creator_id: user._id,
+      type,
+      status,
+      fiat_amount: fiatAmount,
+      fiat_code: fiatCode,
+      payment_method: paymentMethod,
+      tg_chat_id: ctx.message.chat.id,
+      tg_order_message: ctx.message.message_id,
+      price_from_api: priceFromAPI,
+      price_margin: priceMargin || 0,
+      description: buildDescription({
+        user,
+        type,
+        amount,
+        fiatAmount,
+        fiatCode,
+        paymentMethod,
+        priceMargin,
+        priceFromAPI,
+        currency
+      })
+    };
+
+    let order;
+
+    if (type === 'sell') {
+      order = new Order({
+        seller_id: user._id,
+        ...baseOrderData,
+      });
+    } else {
+      order = new Order({
+        buyer_id: user._id,
+        ...baseOrderData,
+      });
+    }
+    await order.save();
+
+    return order;
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+const buildDescription = ({
+  user,
+  type,
+  amount,
+  fiatAmount,
+  fiatCode,
+  paymentMethod,
+  priceMargin,
+  priceFromAPI,
+  currency,
+}) => {
+  try {
+    const action = type == 'sell' ? 'Vendiendo' : 'Comprando';
+    const paymentAction = type == 'sell' ? 'Recibo pago' : 'Pago';
+    const trades = user.trades_completed;
+    const volume = user.volume_traded;
+    const totalRating = user.total_rating;
+    const totalReviews = user.reviews.length;
     const username = user.show_username ? `@${user.username} está ` : ``;
     const volumeTraded = user.show_volume_traded ? `Volumen de comercio: ${volume} sats\n` : ``;
     priceMargin = (!!priceMargin && priceMargin > 0) ? `+${priceMargin}` : priceMargin;
     const priceMarginText = !!priceMargin ? `${priceMargin}%\n` : ``;
-    const currency = getCurrency(fiatCode);
     let currencyString = `${fiatCode} ${fiatAmount}`;
+  
     if (!!currency) {
       currencyString = `${fiatAmount} ${currency.name_plural} ${currency.emoji}`;
     }
+    
     let amountText = `${amount} `;
     let tasaText = '';
-    let rateText = '';
-    let priceFromAPI = false;
-    if (amount == 0) {
-      priceFromAPI = true;
-      if (!currency.price) {
-        await messages.notRateForCurrency(bot, user);
-        return;
-      }
+    if (priceFromAPI) {
       amountText = '';
       tasaText = `Tasa: ${process.env.FIAT_RATE_NAME} ${priceMarginText}\n`;
     } else {
       const exchangePrice = getBtcExchangePrice(fiatAmount, amount);
       tasaText = `Precio: ${exchangePrice.toFixed(2)}\n`
     }
-
+  
+    let rateText = '';
     if (!!totalRating) {
       const stars = getEmojiRate(totalRating);
       const roundedRating = decimalRound(totalRating, -1);
       rateText = `${roundedRating} ${stars} (${totalReviews})\n`;
     }
-
-    if (type === 'sell') {
-      const fee = amount * parseFloat(process.env.FEE);
-      let description = `${username}${action} ${amountText}sats\nPor ${currencyString}\n`;
-      description += `Recibo pago por ${paymentMethod}\n`;
-      description += `Tiene ${trades} operaciones exitosas\n`;
-      description += volumeTraded;
-      description += tasaText;
-      description += rateText;
-      const order = new Order({
-        description,
-        amount,
-        fee,
-        creator_id: seller._id,
-        seller_id: seller._id,
-        type,
-        status,
-        fiat_amount: fiatAmount,
-        fiat_code: fiatCode,
-        payment_method: paymentMethod,
-        tg_chat_id: ctx.message.chat.id,
-        tg_order_message: ctx.message.message_id,
-        price_from_api: priceFromAPI,
-        price_margin: priceMargin || 0,
-      });
-      await order.save();
-
-      return order;
-    } else {
-      const fee = amount * parseFloat(process.env.FEE);
-      let description = `${username}${action} ${amountText}sats\nPor ${currencyString}\n`;
-      description += `Pago por ${paymentMethod}\n`;
-      description += `Tiene ${trades} operaciones exitosas\n`;
-      description += volumeTraded;
-      description += tasaText;
-      description += rateText;
-      const order = new Order({
-        description,
-        amount,
-        fee,
-        creator_id: buyer._id,
-        buyer_id: buyer._id,
-        type,
-        fiat_amount: fiatAmount,
-        fiat_code: fiatCode,
-        payment_method: paymentMethod,
-        status,
-        tg_chat_id: ctx.message.chat.id,
-        tg_order_message: ctx.message.message_id,
-        price_from_api: priceFromAPI,
-        price_margin: priceMargin || 0,
-      });
-      await order.save();
-
-      return order;
-    }
+  
+    let description = `${username}${action} ${amountText}sats\nPor ${currencyString}\n`;
+    description += `${paymentAction} por ${paymentMethod}\n`;
+    description += `Tiene ${trades} operaciones exitosas\n`;
+    description += volumeTraded;
+    description += tasaText;
+    description += rateText;
+  
+    return description
   } catch (e) {
     console.log(e);
   }

--- a/bot/start.js
+++ b/bot/start.js
@@ -87,7 +87,6 @@ const initialize = (botToken, options) => {
       const order = await ordersActions.createOrder(ctx, bot, user, {
         type: 'sell',
         amount,
-        seller: user,
         fiatAmount,
         fiatCode,
         paymentMethod,
@@ -118,7 +117,6 @@ const initialize = (botToken, options) => {
       const order = await ordersActions.createOrder(ctx, bot, user, {
         type: 'buy',
         amount,
-        buyer: user,
         fiatAmount,
         fiatCode,
         paymentMethod,


### PR DESCRIPTION
The objective of this PR is to refactor the function `createOrder` in
meaningful portions of code.

Some things to consider about this function are:
- Heavy use of flags.
- Duplicated parameters.
- Duplicated code.

---

Changes:
- All the logic to build the `description` field was moved to its own function.
- Parameters `buyer` and `seller` removed in favor of `user` parameter.
     > Flags on ternary operators removed due to this change.
- New `paymentAction` variable to increase shared code in description build for
  `buy` and `sell` orders.
- Repeated code to set description in `buy` and `sell` orders was joined and
  only the disjoint fields were left in the conditional logic.

---

Things to consider:
- `priceFromAPI` carries redundant information already present in the `amount`
  parameter, but its readability was preferred over the number of parameters and
  data duplication.
- Although `buildDescription` is a new and different function, its utility is
  totally related to `createOrder`. The objective of these changes is to
  separate and derive sub tasks in code. It was not created to reuse in other
  parts of the code. Hence its private character.

