### PR TITLE
Reply with bot version number

### DIFF
--- a/bot/start.js
+++ b/bot/start.js
@@ -96,6 +96,15 @@ const initialize = (botToken, options) => {
     }
   });
 
+  bot.command('version', async (ctx) => {
+    try {
+      const package = require('../package.json')
+      await ctx.reply(package.version);
+    } catch (err) {
+      console.log(error);
+    }
+  })
+
   bot.command('sell', async (ctx) => {
     try {
       const user = await validateUser(ctx, false);


### PR DESCRIPTION
It would be useful for the user to know which version of the bot is deployed.
Bug reports could include the version number to facilitate analysis.